### PR TITLE
Fix LinkedIn social using incorrect default path and Update GitHub and Twitter to use canonical URL

### DIFF
--- a/_data/const/contact.yml
+++ b/_data/const/contact.yml
@@ -16,7 +16,7 @@ email:
   url: ""
 linkedin:
   icon: "fa fa-linkedin"
-  url: "https://www.linkedin.com"
+  url: "https://www.linkedin.com/in"
 twitter:
   icon: "fa fa-twitter"
   url: "https://www.twitter.com"

--- a/_data/const/contact.yml
+++ b/_data/const/contact.yml
@@ -10,7 +10,7 @@
 
 github:
   icon: "fa fa-github"
-  url: "https://www.github.com"
+  url: "https://github.com"
 email:
   icon: "fa fa-envelope-o"
   url: ""
@@ -19,7 +19,7 @@ linkedin:
   url: "https://www.linkedin.com/in"
 twitter:
   icon: "fa fa-twitter"
-  url: "https://www.twitter.com"
+  url: "https://twitter.com"
 instagram:
   icon: "fa fa-instagram"
   url: "https://www.instagram.com"


### PR DESCRIPTION
Similar to how YouTube uses `/channel`, LinkedIn uses `/in` as a prefix for profiles.