### PR TITLE
Fix display condition of cookie setting button

### DIFF
--- a/_includes/default/nav/navigation-side-nav-bottom-buttons.html
+++ b/_includes/default/nav/navigation-side-nav-bottom-buttons.html
@@ -12,7 +12,7 @@
   {%- assign cookie_settings_button_enabled = true -%}
 {%- endif -%}
 
-{% if color_scheme_switch_enabled == true %}
+{% if color_scheme_switch_enabled == true or cookie_settings_button_enabled == true %}
   <div class="side-nav-bottom-buttons-container">
     <hr>
     <ul>


### PR DESCRIPTION
#### About pull request  
If color_scheme_switch_side_nav is false, side-nav-bottom-buttons-container was not displayed.
Therefore even though cookie_settings_button_enabled is true, the cookie setting button was also not displayed.

#### What's changed to accomplish the problem described in the issue

Add OR condition `cookie_settings_button_enabled == true` for enable `side-nav-bottom-buttons-container`.

The coding rule check is done [yes]

- To get more insight, please check the related issue
 #104.
