### PR TITLE
fix for consent box when single language is used.

### DIFF
--- a/_includes/default/scripts-include.html
+++ b/_includes/default/scripts-include.html
@@ -184,8 +184,12 @@
 {% endif -%}
 
 {% if site.data.lang.size > 1 and site.data.conf.main.language_switch_lang_list.size > 1 and site.data.conf.main.language_translation_offer_box -%}
-  {%- include default/sliding-msg-box.html -%}
+  {%- assign language_translation_offer_box = true -%}
   {%- include multi_lng/lang-offer-msg-box.html -%}
+{% endif -%}
+
+{% if site.data.conf.main.cookie_consent.enable or language_translation_offer_box -%}
+  {%- include default/sliding-msg-box.html -%}
 {% endif -%}
 
 {%- comment -%} iOS Safari Web App fix for open links inside app. (prevent opening in safari) {%- endcomment -%}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,9 +33,13 @@ layout: util/compress_js
 {%- endfor %}
 
 {% if site.data.lang.size > 1 and site.data.conf.main.language_switch_lang_list.size > 1 and site.data.conf.main.language_translation_offer_box -%}
+  {% assign language_translation_offer_box = true %}
   {% include_relative _js/default/check-storage-availability.js %}
-  {% include_relative _js/default/sliding-msg-box.js %}
   {% include_relative _js/default/lang-offer-msg-box.js %}
+{%- endif %}
+
+{% if site.data.conf.main.cookie_consent.enable == true or language_translation_offer_box == true %}
+  {% include_relative _js/default/sliding-msg-box.js %}
 {%- endif %}
 
 {% if site.data.conf.main.cookie_consent.enable == true %}


### PR DESCRIPTION
#### About pull request
- To get more insight, please check the related issue #132.

#### What's changed to accomplish [problem / feature] described in issue
<!-- Please provide a description of the changes proposed in the pull request  -->
- If the consent box or translation offer box is enabled, then include SlidingMsgBox.

Coding rule check is done [yes]

<!--
For beginners

- Please create an issue before creating a pull request. (You will find issue templates which guides you.)
- Create a reference to your issue using #<issue number>.
- A description of the changes proposed in the pull request.
- Check questions and change it [a / b] to [a] or [b]
-->

<!--
#### Coding rule check

Please make sure the following rules are followed

1. spaces and line breaks
    - rule : some code tools change all code syntax. Please make sure no spaces or line breaks have been added or removed unless it is related with the Pull Request
    - why : reviewing diff of codes gets a lot easier, because reviewers can pay attention to a code review.
    - rule : please use editor that supports .editorconfig (https://editorconfig.org). This takes care of charset, line endings and indents.
    - why : reviewing diff of codes gets a lot easier, because reviewers can pay attention to a code review.
2. comments (for all programming languages)
    - rule : comments will be written on the top of the code lines, not the end of code line
    - why : reviewing diff of codes gets a lot easier, because reviewers can pay attention to a code review.
3. for JavaScript's
    - rule : use `/* comment */` comments.
    - why : code compression for JavaScript is not supported if a comment starts with `//`
-->
